### PR TITLE
Pom change maven run spring boot

### DIFF
--- a/hl7-file-input-route/src/main/resources/application.properties
+++ b/hl7-file-input-route/src/main/resources/application.properties
@@ -23,30 +23,3 @@ camel.springboot.routes-collector-enabled=false
 spring.activemq.packages.trust-all=true
 
 server.port=8082
-
-
-
---add-opens=java.base/jdk.internal.access=ALL-UNNAMED
---add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
---add-opens=java.base/sun.nio.ch=ALL-UNNAMED
---add-opens=java.base/sun.util.calendar=ALL-UNNAMED
---add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
---add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
---add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
---add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED
---add-opens=java.base/java.io=ALL-UNNAMED
---add-opens=java.base/java.nio=ALL-UNNAMED
---add-opens=java.base/java.net=ALL-UNNAMED
---add-opens=java.base/java.util=ALL-UNNAMED
---add-opens=java.base/java.util.concurrent=ALL-UNNAMED
---add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED
---add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
---add-opens=java.base/java.lang=ALL-UNNAMED
---add-opens=java.base/java.lang.invoke=ALL-UNNAMED
---add-opens=java.base/java.math=ALL-UNNAMED
---add-opens=java.sql/java.sql=ALL-UNNAMED
---add-opens=java.base/java.lang.reflect=ALL-UNNAMED
---add-opens=java.base/java.time=ALL-UNNAMED
---add-opens=java.base/java.text=ALL-UNNAMED
---add-opens=java.management/sun.management=ALL-UNNAMED
---add-opens java.desktop/java.awt.font=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
+                
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
1. Update pom.xml to add the spring boot maven plugin.  There was an issue running the examples from the command line.
2. Remove the vm args from application.properties which were added by mistake.